### PR TITLE
Implement sauce selection for combos

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,9 @@ import { CartBar } from "@/components/cart-bar";
 import { CartModal } from "@/components/cart-modal";
 import { Header } from "@/components/header";
 import { MenuSection } from "@/components/menu-section";
+import ComboSauceModal from "@/components/combo-sauce-modal";
 import { CartItem, MenuItem } from "@/types/data.type";
+import { uuidV4 } from "@/utils/uuid";
 import { useState } from "react";
 
 const menuItems: MenuItem[] = [
@@ -17,6 +19,7 @@ const menuItems: MenuItem[] = [
     image: "/placeholder.svg?height=200&width=300",
     category: "combo",
     spicyLevel: 2,
+    sauceCount: 1,
   },
   {
     id: "combo-2",
@@ -27,6 +30,7 @@ const menuItems: MenuItem[] = [
     category: "combo",
     popular: true,
     spicyLevel: 3,
+    sauceCount: 2,
   },
   {
     id: "combo-3",
@@ -37,6 +41,7 @@ const menuItems: MenuItem[] = [
     category: "combo",
     popular: true,
     spicyLevel: 3,
+    sauceCount: 3,
   },
   {
     id: "combo-4",
@@ -46,6 +51,7 @@ const menuItems: MenuItem[] = [
     image: "/placeholder.svg?height=200&width=300",
     category: "combo",
     spicyLevel: 2,
+    sauceCount: 4,
   },
   {
     id: "combo-5",
@@ -55,6 +61,7 @@ const menuItems: MenuItem[] = [
     image: "/placeholder.svg?height=200&width=300",
     category: "combo",
     spicyLevel: 4,
+    sauceCount: 4,
   },
   // Extras
   {
@@ -95,27 +102,42 @@ const menuItems: MenuItem[] = [
 export default function NocheAlitasLanding() {
   const [cartItems, setCartItems] = useState<CartItem[]>([]);
   const [showCartModal, setShowCartModal] = useState(false);
+  const [comboToCustomize, setComboToCustomize] = useState<MenuItem | null>(null);
+  const [showSauceModal, setShowSauceModal] = useState(false);
 
-  const addToCart = (item: MenuItem) => {
+  const addItemToCart = (item: MenuItem, sauces: string[] = []) => {
     setCartItems((prevItems) => {
-      const existingItem = prevItems.find((cartItem) => cartItem.id === item.id);
-
-      if (existingItem) {
-        return prevItems.map((cartItem) =>
-          cartItem.id === item.id ? { ...cartItem, quantity: cartItem.quantity + 1 } : cartItem
-        );
-      } else {
-        return [...prevItems, { ...item, quantity: 1 }];
+      if (item.category !== "combo") {
+        const existingItem = prevItems.find((cartItem) => cartItem.id === item.id);
+        if (existingItem) {
+          return prevItems.map((cartItem) =>
+            cartItem.id === item.id ? { ...cartItem, quantity: cartItem.quantity + 1 } : cartItem
+          );
+        }
       }
+
+      return [
+        ...prevItems,
+        { ...item, quantity: 1, selectedSauces: sauces, cartId: uuidV4() },
+      ];
     });
   };
 
-  const updateQuantity = (itemId: string, newQuantity: number) => {
+  const handleAddToCart = (item: MenuItem) => {
+    if (item.category === "combo" && item.sauceCount && item.sauceCount > 0) {
+      setComboToCustomize(item);
+      setShowSauceModal(true);
+    } else {
+      addItemToCart(item);
+    }
+  };
+
+  const updateQuantity = (cartId: string, newQuantity: number) => {
     if (newQuantity <= 0) {
-      setCartItems((prevItems) => prevItems.filter((item) => item.id !== itemId));
+      setCartItems((prevItems) => prevItems.filter((item) => item.cartId !== cartId));
     } else {
       setCartItems((prevItems) =>
-        prevItems.map((item) => (item.id === itemId ? { ...item, quantity: newQuantity } : item))
+        prevItems.map((item) => (item.cartId === cartId ? { ...item, quantity: newQuantity } : item))
       );
     }
   };
@@ -133,6 +155,9 @@ export default function NocheAlitasLanding() {
     cartItems.forEach((item) => {
       message += `• *${item.name}* x${item.quantity}\n`;
       message += `  ${item.description}\n`;
+      if (item.selectedSauces && item.selectedSauces.length > 0) {
+        message += `  Salsas: ${item.selectedSauces.join(", ")}\n`;
+      }
       message += `  $${item.price} c/u = $${(item.price * item.quantity).toFixed(2)}\n\n`;
     });
 
@@ -160,7 +185,19 @@ export default function NocheAlitasLanding() {
       <div className='bg-gradient-to-r from-slate-900 via-blue-900 to-slate-800'>
         <Header />
         {/* <HeroSection /> */}
-        <MenuSection menuItems={menuItems} onAddToCart={addToCart} />
+        <MenuSection menuItems={menuItems} onAddToCart={handleAddToCart} />
+        <ComboSauceModal
+          combo={comboToCustomize}
+          isOpen={showSauceModal}
+          onClose={() => setShowSauceModal(false)}
+          onConfirm={(sauces) => {
+            if (comboToCustomize) {
+              addItemToCart(comboToCustomize, sauces);
+            }
+            setShowSauceModal(false);
+            setComboToCustomize(null);
+          }}
+        />
         <CartBar cartItems={cartItems} onViewCart={() => setShowCartModal(true)} />
         <CartModal
           isOpen={showCartModal}

--- a/src/components/cart-modal.tsx
+++ b/src/components/cart-modal.tsx
@@ -10,7 +10,7 @@ interface CartModalProps {
   isOpen: boolean;
   cartItems: CartItem[];
   onClose: () => void;
-  onUpdateQuantity: (itemId: string, newQuantity: number) => void;
+  onUpdateQuantity: (cartId: string, newQuantity: number) => void;
   onOrderNow: () => void;
   onClearCart: () => void;
 }
@@ -86,7 +86,7 @@ export function CartModal({
             <div className='space-y-4'>
               {cartItems.map((item) => (
                 <div
-                  key={item.id}
+                  key={item.cartId}
                   className='bg-slate-700 rounded-lg p-4 border border-slate-600 hover:border-yellow-400 transition-all duration-200'>
                   <div className='flex items-start gap-4'>
                     {/* Imagen del producto */}
@@ -107,7 +107,10 @@ export function CartModal({
                     {/* Información del producto */}
                     <div className='flex-1'>
                       <h4 className='text-orange-400 font-bold text-lg'>{item.name}</h4>
-                      <p className='text-gray-300 text-sm mb-2'>{item.description}</p>
+                      <p className='text-gray-300 text-sm mb-1'>{item.description}</p>
+                      {item.selectedSauces && item.selectedSauces.length > 0 && (
+                        <p className='text-gray-400 text-xs mb-1'>Salsas: {item.selectedSauces.join(', ')}</p>
+                      )}
                       <p className='text-yellow-400 font-bold'>${item.price} c/u</p>
                     </div>
 
@@ -115,7 +118,7 @@ export function CartModal({
                     <div className='flex flex-col items-end gap-2'>
                       <div className='flex items-center gap-2 bg-slate-800 rounded-lg p-1'>
                         <Button
-                          onClick={() => onUpdateQuantity(item.id, item.quantity - 1)}
+                          onClick={() => onUpdateQuantity(item.cartId, item.quantity - 1)}
                           className='w-8 h-8 p-0 bg-red-500 hover:bg-red-600 rounded-md'
                           icon={<Minus className='w-4 h-4' />}
                         />
@@ -123,7 +126,7 @@ export function CartModal({
                           {item.quantity}
                         </span>
                         <Button
-                          onClick={() => onUpdateQuantity(item.id, item.quantity + 1)}
+                          onClick={() => onUpdateQuantity(item.cartId, item.quantity + 1)}
                           className='w-8 h-8 p-0 bg-green-500 hover:bg-green-600 rounded-md'
                           icon={<Plus className='w-4 h-4' />}
                         />

--- a/src/components/combo-sauce-modal.tsx
+++ b/src/components/combo-sauce-modal.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { salsas } from "@/constants/data";
+import { MenuItem } from "@/types/data.type";
+import { useEffect, useState } from "react";
+import { MultiSelect } from "primereact/multiselect";
+import Button from "./Buttons/Button";
+
+interface ComboSauceModalProps {
+  combo: MenuItem | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (sauces: string[]) => void;
+}
+
+export default function ComboSauceModal({
+  combo,
+  isOpen,
+  onClose,
+  onConfirm,
+}: ComboSauceModalProps) {
+  const [selected, setSelected] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setSelected([]);
+    }
+  }, [isOpen]);
+
+  if (!isOpen || !combo) return null;
+
+  const max = combo.sauceCount ?? 0;
+
+  return (
+    <div className='fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center p-4 z-50'>
+      <div className='bg-slate-800 rounded-lg w-full max-w-md border-2 border-yellow-400 shadow-2xl p-6'>
+        <h3 className='text-xl font-bold text-yellow-400 mb-2'>Escoge tus salsas</h3>
+        <p className='text-orange-400 mb-4'>Puedes elegir {max} salsa{max > 1 ? "s" : ""}</p>
+        <MultiSelect
+          value={selected}
+          options={salsas}
+          onChange={(e) => setSelected(e.value)}
+          selectionLimit={max}
+          display='chip'
+          className='w-full mb-4'
+        />
+        <div className='flex justify-end gap-2'>
+          <Button
+            onClick={onClose}
+            className='bg-slate-600 hover:bg-slate-500 text-white px-4 py-2 rounded-md'
+            label='Cancelar'
+          />
+          <Button
+            onClick={() => onConfirm(selected)}
+            disabled={selected.length !== max}
+            className='bg-green-500 hover:bg-green-600 disabled:bg-gray-500 text-white px-4 py-2 rounded-md'
+            label='Agregar'
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/types/data.type.ts
+++ b/src/types/data.type.ts
@@ -7,8 +7,11 @@ export interface MenuItem {
   category: "combo" | "extra" | "bebida";
   popular?: boolean;
   spicyLevel?: number;
+  sauceCount?: number;
 }
 
 export interface CartItem extends MenuItem {
   quantity: number;
+  selectedSauces?: string[];
+  cartId: string;
 }


### PR DESCRIPTION
## Summary
- extend cart and menu types with sauce and cart IDs
- add a modal for choosing sauces when adding combos
- track selections in the cart and include them in WhatsApp messages
- update cart modal to show sauces and handle unique cart items

## Testing
- `npm run lint` *(fails: several eslint errors)*
- `npm run build` *(fails: missing next-sitemap config)*

------
https://chatgpt.com/codex/tasks/task_e_68898ab07690832dacf94dd4ed1850d7